### PR TITLE
Fix nav dropdown responsive

### DIFF
--- a/wizixo/template/assets/css/custom.css
+++ b/wizixo/template/assets/css/custom.css
@@ -1,9 +1,14 @@
 @media (max-width: 1440px) {
-  .nav-item:nth-last-of-type(1) > .dropdown-menu {
-    left: -65vh;
+  .nav-item:nth-last-of-type(1) {
+    position: unset;
   }
 
-  .nav-item:nth-last-of-type(2) > .dropdown-menu {
-    left: -40vh;
+  .navbar-nav {
+    position: relative;
+  }
+
+  .nav-item:nth-last-of-type(-n + 2) > .dropdown-menu {
+    right: 0px;
+    left: unset;
   }
 }

--- a/wizixo/template/assets/css/custom.css
+++ b/wizixo/template/assets/css/custom.css
@@ -1,5 +1,5 @@
 @media (max-width: 1440px) {
-  .nav-item:nth-last-of-type(-n + 1) > .dropdown-menu {
+  .nav-item:nth-last-of-type(1) > .dropdown-menu {
     left: -65vh;
   }
 

--- a/wizixo/template/assets/css/custom.css
+++ b/wizixo/template/assets/css/custom.css
@@ -1,0 +1,9 @@
+@media (max-width: 1440px) {
+  .nav-item:nth-last-of-type(-n + 1) > .dropdown-menu {
+    left: -65vh;
+  }
+
+  .nav-item:nth-last-of-type(2) > .dropdown-menu {
+    left: -40vh;
+  }
+}

--- a/wizixo/template/mint-main.html
+++ b/wizixo/template/mint-main.html
@@ -25,6 +25,9 @@
 	<!-- Theme CSS -->
 	<link rel="stylesheet" type="text/css" href="assets/css/style.css" />
 
+	<!-- Custom CSS -->
+	<link rel="stylesheet" type="text/css" href="assets/css/custom.css" />
+
 </head>
 
 <body>


### PR DESCRIPTION
The bug:
![image](https://user-images.githubusercontent.com/22357579/127757162-213354fc-ed20-49b7-8831-69634feaa9af.png)

this bug is caused by the dropdown menu on navbar:
![image](https://user-images.githubusercontent.com/22357579/127757176-1768565b-69b3-4fa0-897e-68197c999e8a.png)
if we scroll the page, the white area will disappear, but the menu dont show complete:
![image](https://user-images.githubusercontent.com/22357579/127757194-f19224df-1189-4e1b-ba4c-3754e0d7e730.png)

so, I just add a new media query on the last two items and add a left position to pull it:
![image](https://user-images.githubusercontent.com/22357579/127757325-31d4028d-d8f6-4bb3-b54c-62b23c93bc89.png)

another option is use this dropdown from the theme:
![image](https://user-images.githubusercontent.com/22357579/127757359-0786ea7c-a076-49a8-ae76-3b354154e514.png)

(sorry if my inglish is not good)
