### PR TITLE
[UPDATED README] Removed global installation command.

### DIFF
--- a/wizixo/README.md
+++ b/wizixo/README.md
@@ -26,23 +26,17 @@ The `template` directory contains all the template files and static resources. T
 
 #### Gulpfile.js
 
-We've also included an optional Gulp file to help you get started with theme customization. You’ll need to install Node.js and Gulp before using our included gulpfile.js.
+We've also included an optional Gulp file to help you get started with theme customization. You’ll need to install Node.js and the dependencies before using our included gulpfile.js.
 
 To install Node visit [https://nodejs.org/download](https://nodejs.org/download/).
 
-To install gulp, run the following command:
-
-```bash
-$ npm install gulp -g
-```
-
-When you’re done, install the rest of the theme's dependencies:
+When you’re done, install all dependencies by running:
 
 ```
 $ npm install
 ```
 
-From here, simply run `gulp` from your terminal and you're good to go!
+From here, simply run `gulp` or `npm start` from your terminal and you're good to go!
 
 + `gulp` - recompiles your theme assets.
 


### PR DESCRIPTION
Global installation of packages can cause issue with node projects which has them listed in their dependency. Issue #9 was an example. Since `gulp` is already listed in package.json , `npm install` will do the job.