### PR TITLE
Mobile menu icon

### DIFF
--- a/wizixo/template/assets/scss/custom/_navbar.scss
+++ b/wizixo/template/assets/scss/custom/_navbar.scss
@@ -70,6 +70,9 @@
 }
 
 .navbar-primary .navbar-toggler {
+  padding: 0.5em;
+  margin-right: -0.35em;
+  
   .navbar-toggler-icon {
     width: 30px;
     height: 25px;

--- a/wizixo/template/assets/scss/custom/_navbar.scss
+++ b/wizixo/template/assets/scss/custom/_navbar.scss
@@ -69,8 +69,69 @@
   }
 }
 
-.navbar-primary .navbar-toggler-icon {
-    background-image: $navbar-primary-toggler-icon-bg;
+.navbar-primary .navbar-toggler {
+  .navbar-toggler-icon {
+    width: 30px;
+    height: 25px;
+    position: relative;
+    margin: 3px 0px 0px;
+    transform: rotate(0deg);
+    transition: 0.5s ease-in-out;
+
+    span {
+      display: block;
+      background-color: white;
+      position: absolute;
+      height: 3px;
+      width: 100%;
+      border-radius: 9px;
+      opacity: 1;
+      left: 0;
+      transform: rotate(0deg);
+      transition: 0.25s ease-in-out;
+
+      // Hamburger
+      &:nth-child(1) {
+        top: 0px;
+      }
+
+      &:nth-child(2),
+      &:nth-child(3) {
+        top: 10px;
+      }
+
+      &:nth-child(4) {
+        top: 20px;
+      }
+    }
+  }
+
+  &[aria-expanded="true"] {
+    .navbar-toggler-icon {
+      // Cross
+      span {
+        &:nth-child(1) {
+          top: 11px;
+          width: 0%;
+          left: 50%;
+        }
+
+        &:nth-child(2) {
+          transform: rotate(45deg);
+        }
+
+        &:nth-child(3) {
+          transform: rotate(-45deg);
+        }
+
+        &:nth-child(4) {
+          top: 11px;
+          width: 0%;
+          left: 50%;
+        }
+      }
+    }
+  }
 }
 
 @include media-breakpoint-down(lg){

--- a/wizixo/template/mint-section-header.html
+++ b/wizixo/template/mint-section-header.html
@@ -116,13 +116,13 @@
 				</a>
 				<!-- Menu opener button -->
 				<button class="navbar-toggler ml-auto" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
-				  <div class="navbar-toggler-icon">
+					<div class="navbar-toggler-icon">
 						<span></span>
 						<span></span>
 						<span></span>
 						<span></span>
 					</div>
-			  </button>
+				</button>
 				<!-- Main Menu Start -->
 				<div class="collapse navbar-collapse" id="navbarCollapse">
 					<ul class="navbar-nav ml-auto">

--- a/wizixo/template/mint-section-header.html
+++ b/wizixo/template/mint-section-header.html
@@ -116,7 +116,12 @@
 				</a>
 				<!-- Menu opener button -->
 				<button class="navbar-toggler ml-auto" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
-				  <span class="navbar-toggler-icon"> </span>
+				  <div class="navbar-toggler-icon">
+						<span></span>
+						<span></span>
+						<span></span>
+						<span></span>
+					</div>
 			  </button>
 				<!-- Main Menu Start -->
 				<div class="collapse navbar-collapse" id="navbarCollapse">


### PR DESCRIPTION
Improve the mobile menu icon:
- show a cross icon when the menu is open, so it is clear it closes the menu
- animate between the hamburger and the cross icon, inspired by [this example](https://mdbootstrap.com/docs/b4/jquery/navigation/hamburger-menu/#animations)
- increase click area to make the button more user friendly

![image](https://user-images.githubusercontent.com/1136720/128163964-2a7dc442-f0bb-4fce-8021-de8e835b0707.png)
