### PR TITLE
Removed left border for first question on main page

### DIFF
--- a/wizixo/template/mint-page-main.html
+++ b/wizixo/template/mint-page-main.html
@@ -173,7 +173,7 @@
 				</div>
 			</div>
 			<div class="row">
-				<div class="col-md-3 mt-4 all-text-white primary-border-left-dotted py-4">
+				<div class="col-md-3 mt-4 all-text-white py-4">
 					<h4>Is it free?</h4>
 					<p>Yes, Linux Mint is completely free of charge. Almost everything in Linux Mint is also open-source.</p>
 				</div>


### PR DESCRIPTION
On the main page, near the questions section there is an extra border on the first question. This have been removed to maintain uniformity on both sides.

Before:
<img width="1261" alt="with-border-left" src="https://user-images.githubusercontent.com/20491952/128379215-28554af6-eaf7-4391-9f06-4779c189bf08.png">


After:
<img width="1260" alt="without-border-left" src="https://user-images.githubusercontent.com/20491952/128379228-490af1dc-db77-4f1b-bdf3-c5c79e6472d1.png">
